### PR TITLE
Use Travis's container-based architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ install:
  - wget http://downloads.sourceforge.net/project/osal/osal-4.2.1a-release.tar.gz
  - tar -xf osal-4.2.1a-release.tar.gz
  - mv osal-4.2.1a-release cFE/osal
+# Pull WiringPi and move it into the cFE library includes folder
 before_script:
  - git clone https://github.com/CACTUS-Mission/WiringPi.git
  - mv WiringPi/wiringPi/* cFE/apps/inc
+# Don't edit this section (script). It should be the same for all cFS apps. -Ezra
 script:
  - mv for_build cFE/apps/$CFS_APP_NAME/fsw
  - mv mission_inc cFE/apps/$CFS_APP_NAME/fsw

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,17 @@ addons:
 # Set the app name for later in this script
 before_install:
  - export CFS_APP_NAME=vc0706
-# Install dependencies for this app here
+# Don't edit this section (install). It should be the same for all cFS apps. -Ezra
 install:
- - git clone https://github.com/CACTUS-Mission/WiringPi.git
- - cd WiringPi
- - ./build
- - cd ..
-# Don't touch anything below this. Ever. You will regret it. -Ezra
-before_script:
  - git clone https://github.com/CACTUS-Mission/cFE.git
  - mkdir cFE/apps/$CFS_APP_NAME cFE/apps/$CFS_APP_NAME/fsw
  - rm -rf cFE/osal/
  - wget http://downloads.sourceforge.net/project/osal/osal-4.2.1a-release.tar.gz
  - tar -xf osal-4.2.1a-release.tar.gz
  - mv osal-4.2.1a-release cFE/osal
+before_script:
+ - git clone https://github.com/CACTUS-Mission/WiringPi.git
+ - mv WiringPi/wiringPi/* cFE/apps/inc
 script:
  - mv for_build cFE/apps/$CFS_APP_NAME/fsw
  - mv mission_inc cFE/apps/$CFS_APP_NAME/fsw

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: c
+# Install apt dependencies
+addons:
+    apt:
+        packages:
+            - gcc-multilib
+            - g++-multlib
+            - gcc-arm-linux-gnueabihf
+            - g++-arm-linux-gnueabihf
 # Set the app name for later in this script
 before_install:
  - export CFS_APP_NAME=vc0706
 # Install dependencies for this app here
 install:
- - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
- - sudo apt-get -qq update
- - sudo apt-get install -y gcc-multilib g++-multilib gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
  - git clone https://github.com/CACTUS-Mission/WiringPi.git
  - cd WiringPi
  - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
     apt:
         packages:
             - gcc-multilib
-            - g++-multlib
             - gcc-arm-linux-gnueabihf
             - g++-arm-linux-gnueabihf
 # Set the app name for later in this script

--- a/for_build/Makefile
+++ b/for_build/Makefile
@@ -33,7 +33,7 @@ SOURCES = $(OBJS:.o=.c)
 ##
 ## Specify extra C Flags needed to build this subsystem
 ##
-LOCAL_COPTS = -lwiringpi
+LOCAL_COPTS = 
 
 
 ##
@@ -95,8 +95,7 @@ INCLUDE_PATH = \
 -I$(CFS_APP_SRC)/$(APPTARGET)/fsw/src \
 -I$(CFS_MISSION_INC) \
 -I../cfe/inc \
--I../inc \
--I/usr/local/include
+-I../inc
 
 ##
 ## Define the VPATH make variable. 


### PR DESCRIPTION
This will allow us to test builds locally in the future by using Travis's Docker images to ensure we have an identical test environment.